### PR TITLE
fix: Fix virtual organizing tool and update images

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,10 +103,10 @@
             <div class="organize-container">
                 <div id="cluttered-area" class="organize-area">
                     <h3>Cluttered</h3>
-                    <img src="https://images.pexels.com/photos/1034574/pexels-photo-1034574.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1" alt="A pile of books" class="organize-item" draggable="true" id="item1">
-                    <img src="https://images.pexels.com/photos/3707578/pexels-photo-3707578.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1" alt="A messy wardrobe" class="organize-item" draggable="true" id="item2">
-                    <img src="https://images.pexels.com/photos/264787/pexels-photo-264787.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1" alt="A cluttered desk" class="organize-item" draggable="true" id="item3">
-                    <img src="https://images.pexels.com/photos/1643384/pexels-photo-1643384.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1" alt="A messy kitchen counter" class="organize-item" draggable="true" id="item4">
+                    <img src="https://images.pexels.com/photos/5824901/pexels-photo-5824901.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1" alt="A pile of clothes" class="organize-item" draggable="true" id="item1">
+                    <img src="https://images.pexels.com/photos/1390403/pexels-photo-1390403.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1" alt="A stack of papers" class="organize-item" draggable="true" id="item2">
+                    <img src="https://images.pexels.com/photos/276554/pexels-photo-276554.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1" alt="A messy shelf" class="organize-item" draggable="true" id="item3">
+                    <img src="https://images.pexels.com/photos/3756879/pexels-photo-3756879.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1" alt="A cluttered table" class="organize-item" draggable="true" id="item4">
                 </div>
                 <div id="organized-area" class="organize-area">
                     <h3>Organized</h3>

--- a/script.js
+++ b/script.js
@@ -121,6 +121,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const draggableElement = document.getElementById(id);
             if (draggableElement) {
                 organizedArea.appendChild(draggableElement);
+                draggableElement.style.display = 'block';
             }
             organizedArea.classList.remove('over');
         });
@@ -140,6 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const draggableElement = document.getElementById(id);
             if (draggableElement) {
                 clutteredArea.appendChild(draggableElement);
+                draggableElement.style.display = 'block';
             }
             clutteredArea.classList.remove('over');
         });


### PR DESCRIPTION
This commit fixes the 'virtual organizing' tool by ensuring that the dragged items are visible after being dropped.

This commit also updates the images in the 'virtual organizing' tool to be more representative of a cluttered household.